### PR TITLE
Add metadata to version 3.10 CD documentation

### DIFF
--- a/versioned_docs/version-3.10/operator-guide/cd/argocd-integration.md
+++ b/versioned_docs/version-3.10/operator-guide/cd/argocd-integration.md
@@ -1,3 +1,9 @@
+---
+title: "Argo CD Integration"
+description: "Learn how to integrate Argo CD with KubeRocketCI for continuous delivery, including configuration steps and optional features like remote cluster deployment."
+sidebar_label: "Argo CD Integration"
+---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -44,16 +50,16 @@ edp-grub
 ├── LICENSE
 ├── README.md
 ├── apps                      ### All Argo CD Applications are stored here
-│   ├── grub-argocd.yaml      # Application that provisions Argo CD Resources - Argo Projects (KubeRocketCI Tenants)
-│   └── grub-keycloak.yaml    # Application that provisions Keycloak Resources - Argo CD Groups (KubeRocketCI Tenants)
+│   ├── grub-argocd.yaml      # Application that provisions Argo CD Resources - Argo Projects (KubeRocketCI Tenants)
+│   └── grub-keycloak.yaml    # Application that provisions Keycloak Resources - Argo CD Groups (KubeRocketCI Tenants)
 ├── apps-configs
-│   └── grub
-│       ├── argocd            ### Argo CD resources definition
-│       │   └── edp.yaml
-│       └── keycloak          ### Keycloak resources definition
-│           └── edp.yaml
+│   └── grub
+│       ├── argocd            ### Argo CD resources definition
+│       │   └── edp.yaml
+│       └── keycloak          ### Keycloak resources definition
+│           └── edp.yaml
 ├── bootstrap
-│   └── root.yaml             ### Root application in App of Apps, which provision Applications from /apps
+│   └── root.yaml             ### Root application in App of Apps, which provision Applications from /apps
 └── examples                  ### Examples
     └── tenant
         └── edp-petclinic.yaml

--- a/versioned_docs/version-3.10/operator-guide/cd/auto-stable-trigger-type.md
+++ b/versioned_docs/version-3.10/operator-guide/cd/auto-stable-trigger-type.md
@@ -1,3 +1,9 @@
+---
+title: "Deployment Strategies Overview"
+description: "Explore KubeRocketCI's deployment strategies, including auto-deploy and auto-stable trigger types, to enhance application stability and manage deployment flows."
+sidebar_label: "Deployment Strategies"
+---
+
 # Deployment Strategies Overview
 
 <head>

--- a/versioned_docs/version-3.10/operator-guide/cd/customize-deploy-pipeline.md
+++ b/versioned_docs/version-3.10/operator-guide/cd/customize-deploy-pipeline.md
@@ -1,3 +1,9 @@
+---
+title: "Customize Deploy Pipeline"
+description: "Learn how to customize deployment pipelines in KubeRocketCI to automate pre-deployment and post-deployment steps for enhanced application delivery."
+sidebar_label: "Customize Deploy Pipeline"
+---
+
 # Customize Deploy Pipeline
 
 <head>

--- a/versioned_docs/version-3.10/operator-guide/cd/customize-environment-deletion.md
+++ b/versioned_docs/version-3.10/operator-guide/cd/customize-environment-deletion.md
@@ -1,3 +1,9 @@
+---
+title: "Customize Environment Cleanup"
+description: "Learn how to customize environment cleanup in KubeRocketCI using custom clean pipelines, including creation of TriggerTemplate, Pipeline, and Task resources."
+sidebar_label: "Customize Environment Cleanup"
+---
+
 # Customize Environment Cleanup
 
 <head>

--- a/versioned_docs/version-3.10/operator-guide/cd/deploy-rpm.md
+++ b/versioned_docs/version-3.10/operator-guide/cd/deploy-rpm.md
@@ -1,3 +1,9 @@
+---
+title: "Deploy RPM Packages"
+description: "Learn how to deploy RPM packages in KubeRocketCI using both default and AWX approaches with Ansible integration for Linux distributions."
+sidebar_label: "Deploy RPM Packages"
+---
+
 # Deploy RPM Packages
 
 <head>

--- a/versioned_docs/version-3.10/operator-guide/cd/manual-approval.md
+++ b/versioned_docs/version-3.10/operator-guide/cd/manual-approval.md
@@ -1,3 +1,9 @@
+---
+title: "Manual Approval in Pipelines"
+description: "Implement manual approval workflows in KubeRocketCI pipelines to control application promotion across environments and ensure only verified changes reach production."
+sidebar_label: "Manual Approval in Pipelines"
+---
+
 # Manual Approval in Pipelines
 
 <head>
@@ -50,7 +56,7 @@ If the approval is rejected, the pipeline status will be failed:
 
   ![Manual approve rejected](../../assets/operator-guide/manual_approve_rejected.png "Manual approve rejected")
 
-If you don’t make a selection within the pipeline processing time, which is **60 minutes** by default, you’ll see a crossed clock icon as the task run status, indicating that the pipeline has timed out:
+If you don't make a selection within the pipeline processing time, which is **60 minutes** by default, you'll see a crossed clock icon as the task run status, indicating that the pipeline has timed out:
 
   ![Approval timed out](../../assets/operator-guide/manual_approve_timeout.png "Approval timed out")
 


### PR DESCRIPTION
This PR adds metadata to the version 3.10 operator guide CD documentation files. The metadata includes:

- title
- sidebar_label
- description (optimized for SEO with 155-160 characters)

This will help improve page indexation and SEO performance for the versioned documentation.

Files updated:
- argocd-integration.md
- auto-stable-trigger-type.md
- customize-deploy-pipeline.md
- customize-environment-deletion.md
- deploy-rpm.md
- manual-approval.md